### PR TITLE
Feature: Added Button on Sidebar for Emergency Stop of Pipelines based on Folder and recursive Stop of pipelines in sub folders. + Bump BOM to 5388.v3ea_2e00a_719a_  

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,14 @@
     </dependencies>
   </dependencyManagement>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>cloudbees-folder</artifactId>
+      <version>6.1042.v37b_8229708e4</version>
+    </dependency>
+  </dependencies>
+
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>5294.va_d2e144c80e1</version>
+        <version>5388.v3ea_2e00a_719a_</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/main/java/io/jenkins/plugins/emergencystop/EmergencyFolderStopAction.java
+++ b/src/main/java/io/jenkins/plugins/emergencystop/EmergencyFolderStopAction.java
@@ -12,6 +12,8 @@ import hudson.model.TopLevelItem;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Collections;
+
 import jenkins.model.CauseOfInterruption;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.StaplerRequest2;
@@ -43,6 +45,13 @@ public class EmergencyFolderStopAction implements Action {
     }
 
     public void doStop(StaplerRequest2 req, StaplerResponse2 rsp) throws IOException, ServletException {
+        
+        Jenkins jenkins = Jenkins.get();
+        if (!jenkins.hasPermission(Jenkins.ADMINISTER)) {
+            rsp.sendError(403, "You need ADMIN permission to perform this action");
+            return;
+        }
+
         if (!"GET".equals(req.getMethod())) {
             rsp.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED, "GET required");
             return;

--- a/src/main/java/io/jenkins/plugins/emergencystop/EmergencyFolderStopAction.java
+++ b/src/main/java/io/jenkins/plugins/emergencystop/EmergencyFolderStopAction.java
@@ -18,6 +18,7 @@ import jenkins.model.CauseOfInterruption;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.StaplerResponse2;
+import org.kohsuke.stapler.verb.GET;
 import org.kohsuke.stapler.verb.POST;
 
 public class EmergencyFolderStopAction implements Action {

--- a/src/main/java/io/jenkins/plugins/emergencystop/EmergencyFolderStopAction.java
+++ b/src/main/java/io/jenkins/plugins/emergencystop/EmergencyFolderStopAction.java
@@ -1,0 +1,99 @@
+package io.jenkins.plugins.emergencystop;
+
+import com.cloudbees.hudson.plugins.folder.AbstractFolder;
+import com.cloudbees.hudson.plugins.folder.Folder;
+import hudson.model.Action;
+import hudson.model.Job;
+import hudson.model.Queue;
+import hudson.model.Result;
+import hudson.model.Run;
+import hudson.model.TopLevelItem;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import hudson.model.Executor;
+
+import jenkins.model.CauseOfInterruption;
+import jenkins.model.Jenkins;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
+
+public class EmergencyFolderStopAction implements Action {
+    private final Folder folder;
+
+    public EmergencyFolderStopAction(Folder folder) {
+        this.folder = folder;
+    }
+
+    @Override
+    public String getIconFileName() {
+        Jenkins jenkins = Jenkins.get();
+        return jenkins.hasPermission(Jenkins.ADMINISTER) ? "symbol-warning" : null;
+    }
+
+    @Override
+    public String getDisplayName() {
+        Jenkins jenkins = Jenkins.get();
+        return jenkins.hasPermission(Jenkins.ADMINISTER) ? "Emerg. Stop Folder Pipelines" : null;
+    }
+
+    @Override
+    public String getUrlName() {
+        Jenkins jenkins = Jenkins.get();
+        return jenkins.hasPermission(Jenkins.ADMINISTER) ? "emergency-stop-folder-pipelines" : null;
+    }
+
+    
+    public void doStop(StaplerRequest2 req, StaplerResponse2 rsp) throws IOException, ServletException {
+        if (!"GET".equals(req.getMethod())) {
+            rsp.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED, "GET required");
+            return;
+        }
+
+        try {
+            stopFolderRecursively(folder);
+        } catch (Exception e) {
+            rsp.sendError(500, "Error during emergency stop: " + e.getMessage());
+            return;
+        }
+
+        rsp.setStatus(200);
+    }
+
+    /**
+     * Recursively stops all running builds and queued items in this folder and subfolders.
+     */
+    private void stopFolderRecursively(AbstractFolder<?> currentFolder) {
+        // Stop running builds for jobs in this folder
+        for (TopLevelItem item : currentFolder.getItems()) {
+            if (item instanceof Job<?, ?> job) {
+                for (Run<?, ?> build : job.getBuilds()) {
+                    if (build.isBuilding()) {
+                        Executor executor = build.getExecutor();
+                        if (executor != null) {
+                            executor.interrupt(
+                                Result.ABORTED,
+                                new CauseOfInterruption.UserInterruption(
+                                    "EMERGENCY STOP by " + Jenkins.getAuthentication2().getName()
+                                )
+                            );
+                        }
+                    }
+                }
+            } else if (item instanceof AbstractFolder<?> subFolder) {
+                // Recurse into subfolder
+                stopFolderRecursively(subFolder);
+            }
+        }
+
+        // Cancel queued items for jobs in this folder
+        Queue queue = Jenkins.get().getQueue();
+        for (Queue.Item item : queue.getItems()) {
+            if (item.task instanceof Job<?, ?> job && job.getParent() == currentFolder) {
+                queue.cancel(item);
+            }
+        }
+    }
+
+}

--- a/src/main/java/io/jenkins/plugins/emergencystop/EmergencyFolderStopAction.java
+++ b/src/main/java/io/jenkins/plugins/emergencystop/EmergencyFolderStopAction.java
@@ -18,6 +18,7 @@ import jenkins.model.CauseOfInterruption;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.StaplerResponse2;
+import org.kohsuke.stapler.verb.POST;
 
 public class EmergencyFolderStopAction implements Action {
     private final Folder folder;
@@ -44,6 +45,7 @@ public class EmergencyFolderStopAction implements Action {
         return jenkins.hasPermission(Jenkins.ADMINISTER) ? "emergency-stop-folder-pipelines" : null;
     }
 
+    @GET
     public void doStop(StaplerRequest2 req, StaplerResponse2 rsp) throws IOException, ServletException {
         
         Jenkins jenkins = Jenkins.get();

--- a/src/main/java/io/jenkins/plugins/emergencystop/EmergencyFolderStopAction.java
+++ b/src/main/java/io/jenkins/plugins/emergencystop/EmergencyFolderStopAction.java
@@ -12,7 +12,6 @@ import hudson.model.TopLevelItem;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-
 import jenkins.model.CauseOfInterruption;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.StaplerRequest2;
@@ -46,7 +45,7 @@ public class EmergencyFolderStopAction implements Action {
 
     @GET
     public void doStop(StaplerRequest2 req, StaplerResponse2 rsp) throws IOException, ServletException {
-        
+
         Jenkins jenkins = Jenkins.get();
         if (!jenkins.hasPermission(Jenkins.ADMINISTER)) {
             rsp.sendError(403, "You need ADMIN permission to perform this action");

--- a/src/main/java/io/jenkins/plugins/emergencystop/EmergencyFolderStopAction.java
+++ b/src/main/java/io/jenkins/plugins/emergencystop/EmergencyFolderStopAction.java
@@ -3,6 +3,7 @@ package io.jenkins.plugins.emergencystop;
 import com.cloudbees.hudson.plugins.folder.AbstractFolder;
 import com.cloudbees.hudson.plugins.folder.Folder;
 import hudson.model.Action;
+import hudson.model.Executor;
 import hudson.model.Job;
 import hudson.model.Queue;
 import hudson.model.Result;
@@ -10,10 +11,7 @@ import hudson.model.Run;
 import hudson.model.TopLevelItem;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletResponse;
-
 import java.io.IOException;
-import hudson.model.Executor;
-
 import jenkins.model.CauseOfInterruption;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.StaplerRequest2;
@@ -44,7 +42,6 @@ public class EmergencyFolderStopAction implements Action {
         return jenkins.hasPermission(Jenkins.ADMINISTER) ? "emergency-stop-folder-pipelines" : null;
     }
 
-    
     public void doStop(StaplerRequest2 req, StaplerResponse2 rsp) throws IOException, ServletException {
         if (!"GET".equals(req.getMethod())) {
             rsp.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED, "GET required");
@@ -73,11 +70,9 @@ public class EmergencyFolderStopAction implements Action {
                         Executor executor = build.getExecutor();
                         if (executor != null) {
                             executor.interrupt(
-                                Result.ABORTED,
-                                new CauseOfInterruption.UserInterruption(
-                                    "EMERGENCY STOP by " + Jenkins.getAuthentication2().getName()
-                                )
-                            );
+                                    Result.ABORTED,
+                                    new CauseOfInterruption.UserInterruption("EMERGENCY STOP by "
+                                            + Jenkins.getAuthentication2().getName()));
                         }
                     }
                 }
@@ -95,5 +90,4 @@ public class EmergencyFolderStopAction implements Action {
             }
         }
     }
-
 }

--- a/src/main/java/io/jenkins/plugins/emergencystop/EmergencyFolderStopAction.java
+++ b/src/main/java/io/jenkins/plugins/emergencystop/EmergencyFolderStopAction.java
@@ -12,14 +12,12 @@ import hudson.model.TopLevelItem;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.Collections;
 
 import jenkins.model.CauseOfInterruption;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.StaplerResponse2;
 import org.kohsuke.stapler.verb.GET;
-import org.kohsuke.stapler.verb.POST;
 
 public class EmergencyFolderStopAction implements Action {
     private final Folder folder;

--- a/src/main/java/io/jenkins/plugins/emergencystop/EmergencyFolderStopActionFactory.java
+++ b/src/main/java/io/jenkins/plugins/emergencystop/EmergencyFolderStopActionFactory.java
@@ -5,7 +5,6 @@ import hudson.Extension;
 import hudson.model.Action;
 import java.util.Collection;
 import java.util.Collections;
-
 import jenkins.model.Jenkins;
 import jenkins.model.TransientActionFactory;
 

--- a/src/main/java/io/jenkins/plugins/emergencystop/EmergencyFolderStopActionFactory.java
+++ b/src/main/java/io/jenkins/plugins/emergencystop/EmergencyFolderStopActionFactory.java
@@ -1,0 +1,22 @@
+package io.jenkins.plugins.emergencystop;
+
+import com.cloudbees.hudson.plugins.folder.Folder;
+import hudson.Extension;
+import hudson.model.Action;
+import java.util.Collection;
+import java.util.Collections;
+import jenkins.model.TransientActionFactory;
+
+@Extension
+public class EmergencyFolderStopActionFactory extends TransientActionFactory<Folder> {
+
+    @Override
+    public Class<Folder> type() {
+        return Folder.class;
+    }
+
+    @Override
+    public Collection<? extends Action> createFor(Folder folder) {
+        return Collections.singletonList(new EmergencyFolderStopAction(folder));
+    }
+}

--- a/src/main/java/io/jenkins/plugins/emergencystop/EmergencyFolderStopActionFactory.java
+++ b/src/main/java/io/jenkins/plugins/emergencystop/EmergencyFolderStopActionFactory.java
@@ -5,6 +5,8 @@ import hudson.Extension;
 import hudson.model.Action;
 import java.util.Collection;
 import java.util.Collections;
+
+import jenkins.model.Jenkins;
 import jenkins.model.TransientActionFactory;
 
 @Extension
@@ -17,6 +19,9 @@ public class EmergencyFolderStopActionFactory extends TransientActionFactory<Fol
 
     @Override
     public Collection<? extends Action> createFor(Folder folder) {
+        if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
+            return Collections.emptyList(); // no action for non-admins
+        }
         return Collections.singletonList(new EmergencyFolderStopAction(folder));
     }
 }

--- a/src/main/java/io/jenkins/plugins/emergencystop/SimpleEmergencyStopAction.java
+++ b/src/main/java/io/jenkins/plugins/emergencystop/SimpleEmergencyStopAction.java
@@ -1,7 +1,12 @@
 package io.jenkins.plugins.emergencystop;
 
 import hudson.Extension;
-import hudson.model.*;
+import hudson.model.Executor;
+import hudson.model.Job;
+import hudson.model.Queue;
+import hudson.model.Result;
+import hudson.model.RootAction;
+import hudson.model.Run;
 import jakarta.servlet.ServletException;
 import java.io.IOException;
 import java.util.List;
@@ -69,7 +74,7 @@ public class SimpleEmergencyStopAction implements RootAction {
                             executor.interrupt(
                                     Result.ABORTED,
                                     new CauseOfInterruption.UserInterruption("EMERGENCY STOP by "
-                                            + jenkins.getAuthentication2().getName()));
+                                            + Jenkins.getAuthentication2().getName()));
                             this.stoppedPipelines++;
                         } else {
                             LOGGER.warning("Cannot stop build (no executor): " + build.getFullDisplayName());

--- a/src/main/java/io/jenkins/plugins/emergencystop/SimpleEmergencyStopAction.java
+++ b/src/main/java/io/jenkins/plugins/emergencystop/SimpleEmergencyStopAction.java
@@ -17,8 +17,8 @@ public class SimpleEmergencyStopAction implements RootAction {
 
     private static final Logger LOGGER = Logger.getLogger(SimpleEmergencyStopAction.class.getName());
 
-    public int stoppedPipelines;
-    public int notStoppedPipelines;
+    private int stoppedPipelines;
+    private int notStoppedPipelines;
 
     public int getStoppedPipelines() {
         return stoppedPipelines;

--- a/src/main/resources/io/jenkins/plugins/emergencystop/EmergencyFolderStopAction/action.jelly
+++ b/src/main/resources/io/jenkins/plugins/emergencystop/EmergencyFolderStopAction/action.jelly
@@ -1,0 +1,13 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form">
+
+  <script src="${rootURL}/plugin/emergency-stop-pipelines/index.js"></script>
+
+  <l:task
+    title="Emerg. Stop Folder Pipelines"
+    href="#"
+    id="emergency-stop-folder-pipeline-button"
+    icon="symbol-warning"
+    data-submit-url="emergency-stop-folder-pipelines/stop" />
+      
+</j:jelly>

--- a/src/main/webapp/index.js
+++ b/src/main/webapp/index.js
@@ -1,8 +1,8 @@
-document.addEventListener("DOMContentLoaded", function() {
+document.addEventListener("DOMContentLoaded", function () {
     const form = document.getElementById("emergency-stop-form");
     if (!form) return;
 
-    form.addEventListener("submit", function(event) {
+    form.addEventListener("submit", function (event) {
         event.preventDefault();
 
         dialog.confirm("Abort all pipelines?", {
@@ -12,7 +12,36 @@ document.addEventListener("DOMContentLoaded", function() {
             type: "destructive"
         }).then(
             () => form.submit(),
-            () => {},
+            () => { },
+        );
+    });
+});
+
+document.addEventListener("DOMContentLoaded", function () {
+    const emergency_stop_folder_button = document.getElementById("emergency-stop-folder-pipeline-button");
+    if (!emergency_stop_folder_button) return;
+
+    emergency_stop_folder_button.addEventListener("click", function (event) {
+        event.preventDefault();
+
+        dialog.confirm("Abort all pipelines?", {
+            message: "This will stop all running jobs immediately. Are you sure?",
+            cancelText: dialog.translations.no,
+            okText: dialog.translations.yes,
+            type: "destructive"
+        }).then(
+            () => {
+                fetch(emergency_stop_folder_button.dataset.submitUrl, {
+                    method: "GET",
+                    credentials: "same-origin"
+                }).then(() => {
+                    notificationBar.show('Triggered emergency stop of folder pipelines.', notificationBar.WARNING)
+                }).catch(err => {
+                    notificationBar.show('Failed to stop pipelines.', notificationBar.ERROR)
+                    alert("Failed to stop pipelines: " + err);
+                });
+            },
+            () => { },
         );
     });
 });


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

### Testing done

- Pipelines are aborted when triggered from folder sidebar button.
- Children folder pipelines are aborted recursivelly.
- Testing was done for non-admin and admin users.


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did

### Screenshot of feature (if any) [Optional]

<img width="355" height="442" alt="Screenshot From 2025-09-20 00-16-33" src="https://github.com/user-attachments/assets/40fc2530-3338-4168-b9c8-83acfde7e6bf" />

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
